### PR TITLE
Restore OTA CRC integrity check and add hard reset after BLE DFU

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -336,9 +336,13 @@ endif
 CFLAGS += -DDFU_APP_DATA_RESERVED=$(DFU_APP_DATA_RESERVED)
 
 # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105523
-# Fixes for gcc version 12, 13 and 14.
-ifneq (,$(filter 12.% 13.% 14.%,$(shell $(CC) -dumpversion 2>/dev/null)))
+# Fixes for gcc version 12, 13, 14 and 15.
+ifneq (,$(filter 12.% 13.% 14.% 15.%,$(shell $(CC) -dumpversion 2>/dev/null)))
 	CFLAGS += --param=min-pagesize=0
+	# Suppress false-positive -Warray-bounds on memory-mapped address dereferences in SDK headers
+	CFLAGS += -Wno-array-bounds
+	# Suppress false-positive -Wunterminated-string-initialization on intentional FAT 8.3 name fields
+	CFLAGS += -Wno-unterminated-string-initialization
 endif
 
 #------------------------------------------------------------------------------

--- a/lib/sdk11/components/libraries/bootloader_dfu/dfu_init.h
+++ b/lib/sdk11/components/libraries/bootloader_dfu/dfu_init.h
@@ -116,18 +116,19 @@ uint32_t dfu_init_prevalidate(uint8_t * p_init_data, uint32_t init_data_len, uin
  *           - A signature to ensure the image originates from a trusted source.
  *           Checks are intended to be expanded for customer-specific requirements.
  * 
- * @param[in] p_image    Pointer to the received image. The init data provided in the call 
- *                       \ref dfu_init_prevalidate will be used for validating the image.
- * @param[in] image_len  Length of the image data.
+ * @param[in]  p_image    Pointer to the received image. The init data provided in the call
+ *                        \ref dfu_init_prevalidate will be used for validating the image.
+ * @param[in]  image_len  Length of the image data.
+ * @param[out] p_crc_out  Pointer to store the computed CRC of the image. Set on success.
  *
  * @retval NRF_SUCCESS             If the post-validation succeeded, that meant the integrity of the
- *                                 image has been verified and the image originates from a trusted 
+ *                                 image has been verified and the image originates from a trusted
  *                                 source (signing).
- * @retval NRF_ERROR_INVALID_DATA  If the post-validation failed, that meant the post check of the 
+ * @retval NRF_ERROR_INVALID_DATA  If the post-validation failed, that meant the post check of the
  *                                 image failed such as the CRC is not matching the image transfered
  *                                 or the verification of the image fails (signing).
  */
-uint32_t dfu_init_postvalidate(uint8_t * p_image, uint32_t image_len);
+uint32_t dfu_init_postvalidate(uint8_t * p_image, uint32_t image_len, uint16_t * p_crc_out);
 
 #endif // DFU_INIT_H__
 

--- a/lib/sdk11/components/libraries/bootloader_dfu/dfu_single_bank.c
+++ b/lib/sdk11/components/libraries/bootloader_dfu/dfu_single_bank.c
@@ -497,7 +497,7 @@ uint32_t dfu_image_validate()
             {
                 m_dfu_state = DFU_STATE_VALIDATE;
 
-                err_code = dfu_init_postvalidate((uint8_t *)mp_storage_handle_active->block_id, m_image_size);
+                err_code = dfu_init_postvalidate((uint8_t *)mp_storage_handle_active->block_id, m_image_size, &m_image_crc);
                 VERIFY_SUCCESS(err_code);
                 m_dfu_state = DFU_STATE_WAIT_4_ACTIVATE;
             }

--- a/src/dfu_init.c
+++ b/src/dfu_init.c
@@ -188,11 +188,11 @@ uint32_t dfu_init_prevalidate(uint8_t * p_init_data, uint32_t init_data_len, uin
 }
 
 
-uint32_t dfu_init_postvalidate(uint8_t * p_image, uint32_t image_len)
+uint32_t dfu_init_postvalidate(uint8_t * p_image, uint32_t image_len, uint16_t * p_crc_out)
 {
     uint16_t image_crc;
     uint16_t received_crc;
-    
+
     // In order to support hashing (and signing) then the (decrypted) hash should be fetched and
     // the corresponding hash should be calculated over the image at this location.
     // If hashing (or signing) is added to the system then the CRC validation should be removed.
@@ -200,7 +200,7 @@ uint32_t dfu_init_postvalidate(uint8_t * p_image, uint32_t image_len)
     // calculate CRC from active block.
     image_crc = crc16_compute(p_image, image_len, NULL);
 
-    // Decode the received CRC from extended data.    
+    // Decode the received CRC from extended data.
     received_crc = uint16_decode((uint8_t *)&m_extended_packet[0]);
 
     // Compare the received and calculated CRC.
@@ -209,6 +209,7 @@ uint32_t dfu_init_postvalidate(uint8_t * p_image, uint32_t image_len)
         return NRF_ERROR_INVALID_DATA;
     }
 
+    *p_crc_out = image_crc;
     return NRF_SUCCESS;
 }
 

--- a/src/main.c
+++ b/src/main.c
@@ -317,7 +317,8 @@ static void check_dfu_mode(void) {
 
     if (_ota_dfu) {
       sd_softdevice_disable();
-      usb_teardown(); // allow booting to app after ota even if usb is connected
+      usb_teardown();
+      NVIC_SystemReset(); // clean reset after BLE OTA; GPREGRET is already 0, boots straight to app
     } else {
       usb_teardown();
     }


### PR DESCRIPTION
# Improve BLE OTA reliability: fix discarded CRC and add hard reset after DFU

> Disclaimer: This investigation and the resulting code changes were performed with the assistance of [Claude Code](https://claude.ai/claude-code) (Anthropic). All changes have been reviewed and verified by the author.

## Description of Change

Two improvements to the BLE OTA DFU path, verified on RAK4631 (nRF52840, S140 6.1.1) with MeshCore 1.14.1 via the iOS nRF DFU app. The serial/USB DFU path is unaffected.

---

### 1. OTA CRC was silently discarded (`dfu_init.c`, `dfu_single_bank.c`, `dfu_init.h`)

`dfu_init_postvalidate()` computed and validated the image CRC but never returned it to the caller. `m_image_crc` stayed `0` after every OTA, so `bank_0_crc = 0` was persisted to bootloader settings. Because `bootloader_app_is_valid()` skips the CRC check when `bank_0_crc` is zero, the boot-time integrity check was permanently disabled for any OTA-flashed image.

**Fix:** added `uint16_t * p_crc_out` to `dfu_init_postvalidate()` and updated the call site in `dfu_single_bank.c` to pass `&m_image_crc`. The validated CRC is now stored in `bank_0_crc` and verified on every subsequent boot.

```c
// before
err_code = dfu_init_postvalidate((uint8_t *)mp_storage_handle_active->block_id, m_image_size);

// after
err_code = dfu_init_postvalidate((uint8_t *)mp_storage_handle_active->block_id, m_image_size, &m_image_crc);
```

---

### 2. No hard reset after BLE OTA (`main.c`)

After image activation, the bootloader jumped directly to the application without `NVIC_SystemReset()`. This left nRF52840 peripheral registers and radio state in a post-DFU condition. Additionally, `sd_softdevice_vector_table_base_set()` silently fails when the SoftDevice is already disabled, and its SRAM fallback at `0x20000000` can be zeroed by the application's `.bss` initialisation before the SD is re-enabled.

`GPREGRET` is already cleared to `0` earlier in `check_dfu_mode()`, so a hard reset produces a clean boot directly into the application without re-entering DFU mode.

**Fix:** added `NVIC_SystemReset()` after BLE OTA teardown.

```c
// before
if (_ota_dfu) {
    sd_softdevice_disable();
    usb_teardown();
}

// after
if (_ota_dfu) {
    sd_softdevice_disable();
    usb_teardown();
    NVIC_SystemReset(); // clean reset; GPREGRET is already 0, boots straight to app
}
```

---

### 3. GCC 12–15 compatibility (`Makefile`)

Extended the existing GCC version workaround to cover GCC 15, and added `-Wno-array-bounds` and `-Wno-unterminated-string-initialization` to suppress false-positive warnings on memory-mapped address dereferences in SDK headers and intentional FAT 8.3 filename fields in `ghostfat.c`.

---

## Building and flashing

I used the following commands to build and flash the bootloader:

```zsh
xcode-select --install
brew install --cask gcc-arm-embedded
pip3 install adafruit-nrfutil intelhex
git submodule update --init --recursive
python3 -m venv .venv
source .venv/bin/activate
pip install intelhex adafruit-nrfutil
make BOARD=wiscore_rak4631_board flash-dfu SERIAL=/dev/cu.usbmodem2101
```

---

## Testing

- BLE OTA of MeshCore 1.14.1 on RAK4631 via iOS nRF DFU app: application boots successfully
  after OTA completes.
- Serial DFU path (`adafruit-nrfutil dfu serial`) unaffected.
- Consecutive OTA cycles complete and boot correctly.

