### PR TITLE
dfu: recover serial/USB DFU automatically after a failed flash

### DIFF
--- a/lib/sdk11/components/libraries/bootloader_dfu/bootloader.c
+++ b/lib/sdk11/components/libraries/bootloader_dfu/bootloader.c
@@ -20,6 +20,7 @@
 #include "nrf.h"
 #include "app_error.h"
 #include "nrf_sdm.h"
+#include "nrf_soc.h"   // sd_power_gpregret_set/clr (transport hint while SD is on)
 #include "nrf_mbr.h"
 #include "nordic_common.h"
 #include "crc16.h"
@@ -182,6 +183,53 @@ bool bootloader_app_is_valid(void)
 }
 
 
+/**@brief Remember which transport the update currently in progress is using.
+ *
+ * Summary: record it in GPREGRET at the moment bank 0 is erased, so recovery resumes on the
+ * same transport - a BLE OTA that died mid-flash comes back on BLE even with USB attached,
+ * instead of silently switching.
+ *
+ * Detail: once an update has erased bank 0 the application is gone, so a reset before the
+ * transfer finishes leaves the bootloader choosing a recovery transport from scratch.
+ *
+ * GPREGRET survives soft, pin and watchdog resets but is cleared by a power-on or brownout
+ * reset, which is exactly the scope wanted: after a power loss there is nothing to resume,
+ * and check_dfu_mode() falls back to trying USB first and dropping to BLE if no host
+ * enumerates.
+ *
+ * @param[in] ota  true while a BLE OTA is running. It also tells us the SoftDevice is
+ *                 enabled, so GPREGRET has to be written through the SD API rather than by
+ *                 touching the POWER registers directly.
+ */
+static void dfu_transport_hint_set(bool ota)
+{
+  if ( ota )
+  {
+    (void) sd_power_gpregret_clr(0, 0xFFUL);
+    (void) sd_power_gpregret_set(0, BOOTLOADER_DFU_OTA_RESET_MAGIC);
+  }
+  else
+  {
+    NRF_POWER->GPREGRET = BOOTLOADER_DFU_UF2_RESET_MAGIC;
+  }
+}
+
+/**@brief Drop the transport hint once the update has completed successfully, so the next
+ *        boot runs the new application instead of re-entering DFU.
+ */
+static void dfu_transport_hint_clear(bool ota)
+{
+  if ( ota )
+  {
+    (void) sd_power_gpregret_clr(0, 0xFFUL);
+  }
+  else
+  {
+    NRF_POWER->GPREGRET = 0;
+  }
+}
+
+
 static void bootloader_settings_save(bootloader_settings_t * p_settings)
 {
   if ( is_ota() )
@@ -218,6 +266,9 @@ void bootloader_dfu_update_process(dfu_update_status_t update_status)
 
     m_update_status      = BOOTLOADER_SETTINGS_SAVING;
     bootloader_settings_save(&settings);
+
+    // Transfer finished, there is nothing left to resume.
+    dfu_transport_hint_clear(is_ota());
   }
   else if (update_status.status_code == DFU_UPDATE_SD_COMPLETE)
   {
@@ -293,6 +344,10 @@ void bootloader_dfu_update_process(dfu_update_status_t update_status)
     settings.bank_1      = p_bootloader_settings->bank_1;
 
     bootloader_settings_save(&settings);
+
+    // The application is now invalid: remember the transport so an interrupted transfer
+    // resumes on the same one instead of being re-routed on the next boot.
+    dfu_transport_hint_set(is_ota());
   }
   else if (update_status.status_code == DFU_RESET)
   {

--- a/lib/sdk11/components/libraries/bootloader_dfu/bootloader_types.h
+++ b/lib/sdk11/components/libraries/bootloader_dfu/bootloader_types.h
@@ -27,6 +27,17 @@
 
 #define BOOTLOADER_DFU_START 0xB1
 
+/**@brief GPREGRET values that request a specific DFU transport on the next boot.
+ *
+ * Set by the application to enter DFU deliberately, and also written by the bootloader
+ * itself to remember which transport an in-progress update was using, so that an
+ * interrupted update resumes on the same one. See bootloader_dfu_update_process() and
+ * check_dfu_mode() in main.c.
+ */
+#define BOOTLOADER_DFU_OTA_RESET_MAGIC    0xA8
+#define BOOTLOADER_DFU_SERIAL_RESET_MAGIC 0x4e
+#define BOOTLOADER_DFU_UF2_RESET_MAGIC    0x57
+
 #define BOOTLOADER_SVC_APP_DATA_PTR_GET 0x02
 
 /**@brief DFU Bank state code, which indicates wether the bank contains: A valid image, invalid image, or an erased flash.

--- a/src/main.c
+++ b/src/main.c
@@ -107,9 +107,9 @@ extern void tusb_hal_nrf_power_event(uint32_t event);
  * since it is already in application. In all other case of OTA SD must be initialized
  */
 #define DFU_MAGIC_OTA_APPJUM            BOOTLOADER_DFU_START  // 0xB1
-#define DFU_MAGIC_OTA_RESET             0xA8
-#define DFU_MAGIC_SERIAL_ONLY_RESET     0x4e
-#define DFU_MAGIC_UF2_RESET             0x57
+#define DFU_MAGIC_OTA_RESET             BOOTLOADER_DFU_OTA_RESET_MAGIC     // 0xA8
+#define DFU_MAGIC_SERIAL_ONLY_RESET     BOOTLOADER_DFU_SERIAL_RESET_MAGIC  // 0x4e
+#define DFU_MAGIC_UF2_RESET             BOOTLOADER_DFU_UF2_RESET_MAGIC     // 0x57
 #define DFU_MAGIC_SKIP                  0x6d
 
 #define DFU_DBL_RESET_MAGIC             0x5A1AD5      // SALADS
@@ -119,6 +119,19 @@ extern void tusb_hal_nrf_power_event(uint32_t event);
 
 #define BOOTLOADER_VERSION_REGISTER     NRF_TIMER2->CC[0]
 #define DFU_SERIAL_STARTUP_INTERVAL     1000
+
+// How long we wait for a USB host to enumerate us before giving up on USB DFU.
+//
+// This replaces a literal 3000 in the bootloader_dfu_start() call below, so it is a change of
+// behaviour for the paths that already used it - single-tap reset, UF2 and serial-only - and not
+// only for the recovery added here. It is only observable when nothing enumerates at all, since
+// cancel_timeout_on_usb stops the timer as soon as the host answers: on battery, a device put into
+// DFU deliberately now takes 10 s rather than 3 s to give up and go back to the application.
+//
+// 3 s proved too tight to rely on. Measured on a ProMicro nRF52840, a host re-enumerating the
+// device after repeated resets is not always ready within 3 s, and recovery then flapped to BLE
+// with a perfectly good USB host attached - the exact failure this is meant to remove.
+#define DFU_USB_ENUM_TIMEOUT            10000
 
 // Allow for using reset button essentially to swap between application and bootloader.
 // This is controlled by a flag in the app and is the behavior of CPX and all Arcade boards when using MakeCode.
@@ -212,11 +225,27 @@ int main(void) {
     // clear in case we kept DFU_DBL_RESET_APP there
     (*dbl_reset_mem) = 0;
 
+    /* Drop any leftover DFU transport hint (see dfu_transport_hint_set() in bootloader.c)
+     * so a finished update boots the app on every subsequent reset rather than dropping
+     * back into DFU. Any magic the application asked for was already consumed and zeroed at
+     * the top of check_dfu_mode(), so a hint value still sitting here can only be ours. The
+     * SoftDevice is disabled above, so write GPREGRET directly. */
+    if (NRF_POWER->GPREGRET == DFU_MAGIC_OTA_RESET ||
+        NRF_POWER->GPREGRET == DFU_MAGIC_UF2_RESET ||
+        NRF_POWER->GPREGRET == DFU_MAGIC_SERIAL_ONLY_RESET) {
+      NRF_POWER->GPREGRET = 0;
+    }
+
     // start application
     bootloader_app_start();
   }
 
-  NRF_POWER->GPREGRET = 0xA8; // No application was loaded, reset the system with the OTA DFU update
+  // No valid application to jump to. Reboot into BLE OTA DFU so the device is always
+  // recoverable over *some* transport. This is also the BLE fallback for usb_recovery below:
+  // USB DFU was tried first but no host enumerated us in time. The magic is consumed at the
+  // top of check_dfu_mode(), ahead of the usb_recovery decision, so the reboot lands on BLE
+  // even with USB power still applied.
+  NRF_POWER->GPREGRET = DFU_MAGIC_OTA_RESET;
   NVIC_SystemReset();
 }
 
@@ -286,6 +315,47 @@ static void check_dfu_mode(void) {
     (*dbl_reset_mem) = 0;
   }
 
+  /*------------- Auto-recovery when there is no valid application -------------*/
+  /* Summary: when the only reason to enter DFU is a missing application, come up on USB DFU
+   * and let USB *enumeration* choose the transport - a host that answers keeps us on USB and
+   * re-flashable with no double-tap; if nobody answers we fall back to BLE OTA. Every
+   * explicit request (GPREGRET magics, double reset, DFU+FRESET) is handled above and still
+   * wins outright.
+   *
+   * Detail
+   * ------
+   * A failed serial/USB DFU leaves bank_0 = BANK_INVALID_APP (bootloader.c,
+   * DFU_BANK_0_ERASED). That used to fall straight through to BLE: ble_stack_init() ran,
+   * usb_init() never did, so the device vanished from USB entirely and only a physical
+   * double-tap brought it back. BLE OTA recovered automatically; serial/USB DFU did not.
+   *
+   * The two outcomes:
+   *
+   *   a host enumerates us within DFU_USB_ENUM_TIMEOUT -> stay in USB DFU, so the device is
+   *       immediately re-flashable over serial/UF2 with no double-tap.
+   *   nobody answers (battery, or a dumb charger that pulls VBUS high with no data host)
+   *       -> bootloader_dfu_start() returns on timeout and main() reboots into BLE OTA via
+   *       DFU_MAGIC_OTA_RESET.
+   *
+   * Enumeration is re-evaluated on every boot, including a cold one, so recovery survives
+   * power loss - unlike GPREGRET, which a power-on/brownout reset clears.
+   *
+   * Note on VBUS: gating this on NRF_POWER->USBREGSTATUS.VBUSDETECT first (to skip the wait
+   * when running on battery) does NOT work - measured on a ProMicro nRF52840, VBUSDETECT
+   * still reads 0 this early in boot and only asserts some tens of ms later, so an early
+   * read reports "battery" even with a host attached and would send us to BLE, which is
+   * exactly the behaviour being fixed. Enumeration already subsumes VBUS: no VBUS and
+   * charger-only both simply fail to enumerate. usb_init() copes with VBUS arriving late by
+   * design, registering a POWER USBDETECTED handler as well as sampling the status register.
+   */
+  bool usb_recovery = false;
+
+#ifdef NRF_USBD
+  // Parts without a USB peripheral (eg. nRF52832) keep the previous BLE-only behaviour.
+  if (!valid_app && !dfu_start && !_ota_dfu && !serial_only_dfu && !uf2_dfu && !double_reset) {
+    usb_recovery = true; // try USB DFU first, BLE on enumeration timeout
+  } else
+#endif
   if ((dfu_start || !valid_app) && !serial_only_dfu && !uf2_dfu && !double_reset) {
     _ota_dfu = true; // set default to OTA only when no explicit UF2/serial/dbl-reset
   }
@@ -298,6 +368,14 @@ static void check_dfu_mode(void) {
         screen_draw_ble();
       #endif
       led_state(STATE_BLE_DISCONNECTED);
+
+      /* Re-arm the transport hint. The magic that got us here was consumed above, so
+       * without this a second reset while advertising would fall back to probing USB first
+       * and silently move the device off BLE. There is no valid application to be trapped
+       * out of, and it is dropped again by a successful update or a power-on reset. Written
+       * before the SoftDevice is enabled, so a direct register write is fine. */
+      if (!valid_app) NRF_POWER->GPREGRET = DFU_MAGIC_OTA_RESET;
+
       if (!_sd_inited) mbr_init_sd();
       _sd_inited = true;
       ble_stack_init();
@@ -307,9 +385,12 @@ static void check_dfu_mode(void) {
     }
 
     // Initiate an update of the firmware.
-    if (APP_ASKS_FOR_SINGLE_TAP_RESET() || uf2_dfu || serial_only_dfu) {
-      // If USB is not enumerated in 3s (eg. because we're running on battery), we restart into app.
-      bootloader_dfu_start(_ota_dfu, 3000, true);
+    if (APP_ASKS_FOR_SINGLE_TAP_RESET() || uf2_dfu || serial_only_dfu || usb_recovery) {
+      // If USB is not enumerated within the timeout (eg. we are running on battery, or VBUS
+      // comes from a charger with no data host), this returns and we either restart into the
+      // app (valid app) or reboot into BLE OTA (usb_recovery: main() sets
+      // DFU_MAGIC_OTA_RESET and resets when the application is invalid).
+      bootloader_dfu_start(_ota_dfu, DFU_USB_ENUM_TIMEOUT, true);
     } else {
       // No timeout if bootloader requires user action (double-reset).
       bootloader_dfu_start(_ota_dfu, 0, false);


### PR DESCRIPTION
An interrupted serial/USB DFU left the device reachable only over BLE. The aborted transfer
correctly marks the application invalid (bootloader.c writes bank_0 = BANK_INVALID_APP on
DFU_BANK_0_ERASED), but check_dfu_mode() then defaulted !valid_app to OTA: ble_stack_init()
ran and usb_init() never did, so the device disappeared from USB completely and needed a
physical double-tap to come back. BLE OTA recovered by itself; serial/USB DFU did not.

Now, when nothing but a missing application forces DFU, the bootloader comes up on USB DFU
and lets USB enumeration pick the transport: a host that enumerates us keeps us in USB DFU,
immediately re-flashable with no double-tap, and if nobody answers within
DFU_USB_ENUM_TIMEOUT (battery, or a dumb charger with no data host) bootloader_dfu_start()
returns on timeout and main() reboots into BLE OTA, as it already did when no valid
application exists.

Explicit requests keep priority and are excluded: GPREGRET magics, double reset, DFU+FRESET
buttons. Parts without a USB peripheral keep BLE-only behaviour via the existing NRF_USBD
guard. Enumeration is re-read on every boot, so recovery is power-loss safe - unlike
GPREGRET, which a power-on reset clears.

Gating on NRF_POWER->USBREGSTATUS.VBUSDETECT to skip the wait on battery was tried and does
not work: measured over SWD on a ProMicro nRF52840, VBUSDETECT still reads 0 at this point
in boot and only asserts tens of ms later, so an early read reports 'battery' while a host
is attached and sends the device to BLE - the exact behaviour being fixed. Enumeration
already subsumes VBUS: no VBUS and charger-only both simply fail to enumerate.

The commit also makes an interrupted update resume on the transport it was using, so that
preferring USB cannot hijack a BLE OTA that died mid-flash. The transport is recorded in
GPREGRET at DFU_BANK_0_ERASED, reusing magics the bootloader already understands, so
check_dfu_mode() consumes it with no new decision logic. On the OTA path the SoftDevice is
enabled, so it goes through sd_power_gpregret_clr/set; is_ota() distinguishes the cases. The
hint is dropped on DFU_UPDATE_APP_COMPLETE and before bootloader_app_start(), and re-armed
on BLE entry only while !valid_app, which keeps a device with a working application from
being trapped in DFU. The UF2/MSC path never reports DFU_BANK_0_ERASED, so no hint is set
for it.

One existing value changes, and it is worth calling out rather than leaving in the diff: the
literal 3000 passed to bootloader_dfu_start() becomes DFU_USB_ENUM_TIMEOUT at 10000. That call is
already used by the single-tap reset, UF2 and serial-only paths, so those get the longer wait too.

It is only observable when nothing enumerates at all - cancel_timeout_on_usb stops the timer the
moment a host answers - so the practical effect is that a device put into DFU deliberately while on
battery takes 10 s instead of 3 s to give up and return to the application. 3 s turned out to be
too tight to rely on: measured on a ProMicro nRF52840, a host re-enumerating after repeated resets
is not always ready inside 3 s, and recovery then flapped to BLE with a good USB host attached,
which is the failure this PR exists to remove. If you would rather not touch the existing paths,
the narrower change is to keep 3000 for them and use DFU_USB_ENUM_TIMEOUT only for the recovery
added here - say so and I will split it.

The DFU magics move to bootloader_types.h next to BOOTLOADER_DFU_START so main.c and the
bootloader core share one definition.

Verified on a ProMicro nRF52840 with a J-Link, reading the settings page and GPREGRET over
SWD rather than inferring state from LED blink rates: valid app boots; normal serial flash;
abort + reset lands on USB DFU and re-flashes with no double-tap; same with GPREGRET
cleared; charger-only falls back to BLE; an interrupted BLE OTA resumes on BLE with no USB
device; full BLE OTA still completes; a valid app plus a BLE OTA request is not made sticky;
and nrfjprog --recover plus reflash restores a bad bootloader. Also verified end to end on a
XIAO nRF52840 Sense over an ESP32 USB/IP web-flash bridge: six abort-then-recover cycles,
all six recovered on the first retry with no human action.

Re-verified on the final branch, flashed on its own as well as merged with the others, since you
may take only one of these. On a ProMicro nRF52840 with a J-Link, this branch alone: recovery comes
up as CDC + mass storage with the PROMICRO volume; an interrupted BLE OTA leaves 0xA8 in GPREGRET
and the boot after it stays on BLE instead of switching to USB. The same recovery result merged with
the stall timeout, merged with the retry fix, and with all four together.

Also on a XIAO nRF52840 Sense, which runs S140 7.3.0 rather than 6.1.1 and has no debugger, so the
verdict comes from USB identity instead: after an interrupted serial DFU the board came back in UF2
mode on USB - CDC + mass storage, with INFO_UF2.TXT reporting this branch's build - and not on BLE.
With all four merged, the boot following the stall timeout's self-reset also came up on USB with
mass storage.


---

Related to #40, which asks for exactly this decision to be made by checking whether a USB host is
there at all. It suggests `NRF_USBD->USBADDR > 0` or a VBUS read; this waits for the host to
actually enumerate instead, because the register route does not survive contact with hardware:
measured on a ProMicro nRF52840, `USBREGSTATUS.VBUSDETECT` still reads 0 this early in boot and only
asserts some tens of ms later, so an early read reports "battery" even with a host attached - which
would send the device to BLE exactly when USB was available. Enumeration subsumes VBUS anyway: no
VBUS and a charger with no data host both simply fail to enumerate.

Scope, so the issue is not closed on a half answer: the case that report starts from - no valid
application - now tries USB DFU first and falls back to BLE OTA when nothing enumerates. The
explicit paths (single tap, UF2, serial-only) have had an enumeration timeout all along; this only
lengthens it, from 3 s to 10 s. No general "is a host present" gate is added anywhere else.

---

One of four independent DFU fixes, listed in the order they matter:

1. #47 recover serial/USB DFU automatically after a failed flash
2. #48 reboot when a started transfer goes silent
3. #49 accept a new session after an interrupted transfer
4. #50 add a reboot command so a host can ask for a specific DFU mode

Any subset can be taken, in any order. Verified: all four merge cleanly in five different orders and
in all twelve ordered pairs, and each was flashed and tested on hardware on its own as well as in
combination - 26 of 26 checks on a ProMicro nRF52840 with verdicts read over SWD, plus a XIAO
nRF52840 Sense on a different SoftDevice with no debugger.
