### PR TITLE
dfu serial: add a reboot command so a host can ask for a specific DFU mode

### DIFF
--- a/lib/sdk11/components/libraries/bootloader_dfu/dfu_transport_serial.c
+++ b/lib/sdk11/components/libraries/bootloader_dfu/dfu_transport_serial.c
@@ -230,6 +230,21 @@ static void process_dfu_packet(void * p_event_data, uint16_t event_size)
                         led_state(STATE_WRITING_STARTED);
                         break;
 
+                    case DFU_REBOOT_PACKET:
+                        /* Host asked us to come back in a particular DFU mode. Gives the
+                         * serial transport what BLE already has in BLE_DFU_SYS_RESET, and
+                         * lets a host reach UF2 mode (mass storage) without a physical
+                         * double tap and without erasing the application to force a
+                         * recovery boot. The payload word is the GPREGRET magic to use; an
+                         * empty payload just resets. */
+                        {
+                            uint8_t const * p_mode = (uint8_t const *) packet->params.data_packet.p_data_packet;
+
+                            NRF_POWER->GPREGRET = (packet->params.data_packet.packet_length > 0) ? p_mode[0] : 0;
+                            NVIC_SystemReset();
+                        }
+                        return;
+
                     case STOP_DATA_PACKET:
                         (void)dfu_image_validate();
                         (void)dfu_image_activate();

--- a/lib/sdk11/components/libraries/bootloader_dfu/dfu_types.h
+++ b/lib/sdk11/components/libraries/bootloader_dfu/dfu_types.h
@@ -86,6 +86,35 @@ static inline bool is_sd_existed(void)
 #define DATA_PACKET                     0x04                                                            /**< Packet identifies for a Data Packet. */
 #define STOP_DATA_PACKET                0x05                                                            /**< Packet identifies for the Data Stop Packet. */
 
+/* Local packet-type extensions live at 0xF0 and above.
+ *
+ * Detail: Nordic's legacy DFU defines 0x00..0x05 above, so keeping local additions high
+ * leaves the low range free should that ever be extended, and makes it obvious on the wire
+ * that a type is not part of the standard protocol. The type is carried in a full byte
+ * (p_rpc_cmd_buffer[0]) and only 0x00 is reserved (INVALID_PACKET), so any high value is
+ * available.
+ *
+ * Anything the bootloader does not recognise is dropped by the default case of
+ * process_dfu_packet(), so these are safe for a host to probe with: a bootloader that
+ * predates an extension simply ignores it and carries on.
+ */
+#define DFU_LOCAL_PACKET_BASE           0xF0                                                            /**< Start of the locally defined packet types. */
+
+/**@brief Local extension: ask the bootloader to reboot into a chosen DFU mode.
+ *
+ * Detail: the serial transport has no equivalent of the BLE transport's BLE_DFU_SYS_RESET,
+ * so a host had no way to say "start over" or "come back with mass storage" - the only
+ * routes were a physical double tap or destroying the application to force a recovery boot.
+ *
+ * Payload is one 32-bit word, the GPREGRET magic to boot with (see main.c):
+ *   0x57 UF2 (CDC + MSC)   0x4e serial only (CDC)   0xa8 BLE OTA   0x00 plain reset
+ *
+ * The payload must occupy a whole word: the transport derives its length as
+ * (total_len / 4) - 1 words, so a shorter payload rounds down to zero and the mode is
+ * ignored (the device then simply resets).
+ */
+#define DFU_REBOOT_PACKET               (DFU_LOCAL_PACKET_BASE + 0x06)                                  /**< 0xF6: reboot into the DFU mode given in the payload. */
+
 #define DFU_UPDATE_SD                   0x01                                                            /**< Bit field indicating update of SoftDevice is ongoing. */
 #define DFU_UPDATE_BL                   0x02                                                            /**< Bit field indicating update of bootloader is ongoing. */
 #define DFU_UPDATE_APP                  0x04                                                            /**< Bit field indicating update of application is ongoing. */


### PR DESCRIPTION
The serial transport has no equivalent of the BLE transport's BLE_DFU_SYS_RESET, so a host
has no way to say 'start over' or 'come back with mass storage'. The only routes into UF2
mode were a physical double tap or destroying the application to force a recovery boot -
awkward for anything driving DFU remotely, and impossible for a bootloader update, since a
DFU package cannot carry one.

Adds packet type 0xF6 with a one-word payload holding the GPREGRET magic to boot with:
0x57 UF2 (CDC+MSC), 0x4e serial only, 0xa8 BLE OTA, 0x00 plain reset.

Local packet types are placed at 0xF0 and above (DFU_LOCAL_PACKET_BASE). Nordic defines
0x00..0x05, so keeping local additions high leaves the low range free should that ever be
extended, and makes it obvious on the wire that a type is not part of the standard protocol.
The type is carried in a full byte and only 0x00 is reserved, so any high value is free.

Backward compatible by construction: process_dfu_packet() drops unrecognised types in its
default case, so a bootloader predating this ignores the packet and carries on. Verified by
flashing a build without the change, sending the packet and watching USB - no
re-enumeration, application untouched. A host can therefore probe with it safely and treat
'nothing re-enumerated' as 'older bootloader'.

Verified on a ProMicro nRF52840: from serial-only DFU, mode=uf2 comes back as CDC+MSC with
bank_0 still BANK_VALID_APP, so the application is untouched; mode=ota comes up advertising
with no USB device; mode=app boots the application (program counter read back inside the
application region).

Re-verified on the final branch, alone and merged with the other three. On a ProMicro nRF52840,
read over SWD: mode=uf2 reaches CDC + mass storage, mode=app boots the application, and bank_0 is
unchanged across both reboots. On a XIAO nRF52840 Sense (S140 7.3.0, no debugger): mode=uf2 reaches
UF2 mode, and mode=app boots the application again.

Note the payload must occupy a whole word - the transport derives its length as
(total_len / 4) - 1 words, so a shorter payload rounds down to zero words and the mode is
silently ignored, leaving a plain reset.


---

One of four independent DFU fixes, listed in the order they matter:

1. #47 recover serial/USB DFU automatically after a failed flash
2. #48 reboot when a started transfer goes silent
3. #49 accept a new session after an interrupted transfer
4. #50 add a reboot command so a host can ask for a specific DFU mode

Any subset can be taken, in any order. Verified: all four merge cleanly in five different orders and
in all twelve ordered pairs, and each was flashed and tested on hardware on its own as well as in
combination - 26 of 26 checks on a ProMicro nRF52840 with verdicts read over SWD, plus a XIAO
nRF52840 Sense on a different SoftDevice with no debugger.
