### PR TITLE
dfu: triple tap reset to enter BLE OTA DFU

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,12 +91,41 @@ When in OTA DFU mode, devices advertise using a board-specific name rather than 
 
 ---
 
+## Entering DFU mode
+
+The reset button chooses the DFU transport:
+
+| Reset taps | Result |
+| --- | --- |
+| 1 | Normal boot into the application |
+| 2 | USB DFU — UF2 drive + CDC serial |
+| 3 | BLE OTA DFU |
+
+Each tap has to land within 0.5s of the one before it, the same window the double tap
+already used. After the second tap the status LED blinks three times faster for 0.5s:
+that is the window in which a third tap picks BLE OTA. Let it expire and the device
+drops into USB DFU as it always did, just 0.5s later.
+
+This matters most on boards with no DFU or FRESET button wired, such as the RAK 4631
+and RAK 3401, where BLE OTA DFU could otherwise only be entered from the application
+(buttonless DFU service / `GPREGRET`) or by having no valid application at all. A device
+running firmware that exposes no DFU service had no way in.
+
+A board can opt out by defining `TRIPLE_TAP_BLE_DFU` as `0` in its `board.h`, which
+restores the previous behaviour of a double tap entering USB DFU immediately. It is
+always off on nrf52832, where a GPIO reset clears SRAM and the tap state cannot
+survive.
+
+---
+
 ## Installation
 
 **IMPORTANT:** If you are running a MeshCore companion firmware or Ripple firmware on your device **you will need to run an erase after flashing a new bootloader**. Use the MeshCore web flasher to do the erase, it will guide you to the correct erase firmware for your device. Other erase firmwares will not work, they will not erase the ExtraFS area.
 
 The recommended way to install the bootloader is using the UF2 file.  
 Download the UF2 file for your board (they can be found in the releases with filenames beginning with `update-`), enter UF2 mode (usually by double pressing the reset button within 0.5s) and copy the UF2 file across.
+
+A double tap still gives you the UF2 drive; it just waits an extra 0.5s first, in case you meant to triple tap into BLE OTA DFU. See [Entering DFU mode](#entering-dfu-mode).
 
 If you have somehow managed to accidentally flash an incorrect bootloader to your device you will likely require flashing a full bootloader and SoftDevice zip package using ``adafruit-nrfutil``
 
@@ -117,6 +146,9 @@ In this mode:
 **What to do:**
 - Perform an OTA update using a supported DFU app, **or**
 - Explicitly request UF2/serial mode using **double-reset**.
+
+The reverse also works: **triple-reset** puts a device that boots normally into BLE OTA
+DFU, without needing the application to cooperate.
 
 This behaviour is intentional and prevents devices from getting stuck in UF2 mode after failed OTA updates.
 

--- a/src/boards/boards.c
+++ b/src/boards/boards.c
@@ -436,6 +436,16 @@ void led_state(uint32_t state) {
       #endif
       break;
 
+#if TRIPLE_TAP_BLE_DFU
+    // Waiting to see whether a third tap arrives (see TRIPLE_TAP_BLE_DFU).
+    // Blinks 3x faster than any other state, so the open window is unmistakable.
+    // Only the primary cycle is touched, so whichever mode we end up in still sets
+    // up its own indication from an unchanged starting point.
+    case STATE_DFU_MODE_SELECT:
+      primary_cycle_length = 100;
+      break;
+#endif
+
     default:
       break;
   }

--- a/src/boards/boards.h
+++ b/src/boards/boards.h
@@ -45,6 +45,18 @@
 #define BUTTON_FRESET   BUTTON_2
 #endif
 
+// Triple tap on the reset button enters BLE OTA DFU; double tap still enters USB DFU.
+// A board can opt out by defining this as 0 in its board.h.
+// Not available on nrf52832: its SRAM is cleared by a GPIO reset, so the tap state cannot
+// survive, which is the same reason double tap detection is skipped there.
+#ifndef TRIPLE_TAP_BLE_DFU
+  #ifdef NRF52832_XXAA
+    #define TRIPLE_TAP_BLE_DFU 0
+  #else
+    #define TRIPLE_TAP_BLE_DFU 1
+  #endif
+#endif
+
 // The primary LED is usually Red but not in all cases.
 #define LED_PRIMARY 0
 // The secondary LED, when available, is usually blue.
@@ -91,7 +103,8 @@ enum {
   STATE_WRITING_STARTED,
   STATE_WRITING_FINISHED,
   STATE_BLE_CONNECTED,
-  STATE_BLE_DISCONNECTED
+  STATE_BLE_DISCONNECTED,
+  STATE_DFU_MODE_SELECT
 };
 
 void led_pwm_init(uint32_t led_index, uint32_t led_pin);

--- a/src/main.c
+++ b/src/main.c
@@ -112,9 +112,18 @@ extern void tusb_hal_nrf_power_event(uint32_t event);
 #define DFU_MAGIC_UF2_RESET             0x57
 #define DFU_MAGIC_SKIP                  0x6d
 
+/* Reset-tap state, held in the 4-byte no-init DBL_RESET region (see linker script).
+ * It survives a pin reset, so it records how many taps we have seen so far:
+ * - DFU_DBL_RESET_MAGIC : 1 tap  seen, waiting to see whether a 2nd arrives
+ * - DFU_TPL_RESET_MAGIC : 2 taps seen, waiting to see whether a 3rd arrives
+ * Two taps enter USB DFU, three taps enter BLE OTA DFU. The 3rd-tap window only
+ * exists on boards that set TRIPLE_TAP_BLE_DFU; elsewhere 2 taps enter USB DFU at once.
+ */
 #define DFU_DBL_RESET_MAGIC             0x5A1AD5      // SALADS
+#define DFU_TPL_RESET_MAGIC             0x5A1AD6      // SALADS+1
 #define DFU_DBL_RESET_APP               0x4ee5677e
 #define DFU_DBL_RESET_DELAY             500
+#define DFU_TPL_RESET_DELAY             500
 #define DFU_DBL_RESET_MEM               0x20007F7C
 
 #define BOOTLOADER_VERSION_REGISTER     NRF_TIMER2->CC[0]
@@ -237,9 +246,15 @@ static void check_dfu_mode(void) {
   bool const reason_reset_pin = (NRF_POWER->RESETREAS & POWER_RESETREAS_RESETPIN_Msk) ? true : false;
   bool const double_reset = ((*dbl_reset_mem) == DFU_DBL_RESET_MAGIC) && reason_reset_pin;
 
+  // Third tap of a triple tap: two taps were already seen and armed DFU_TPL_RESET_MAGIC below.
+  // Constant false unless the board opts in, so every branch on it folds away.
+  bool const triple_reset = TRIPLE_TAP_BLE_DFU &&
+                            ((*dbl_reset_mem) == DFU_TPL_RESET_MAGIC) && reason_reset_pin;
+
   // start either serial, uf2 or ble
   bool dfu_start = _ota_dfu || serial_only_dfu || uf2_dfu ||
-                   (((*dbl_reset_mem) == DFU_DBL_RESET_MAGIC) && reason_reset_pin);
+                   (((*dbl_reset_mem) == DFU_DBL_RESET_MAGIC) && reason_reset_pin) ||
+                   triple_reset;
 
   // Clear GPREGRET if it is our values
   if (dfu_start || dfu_skip) NRF_POWER->GPREGRET = 0;
@@ -279,6 +294,23 @@ static void check_dfu_mode(void) {
     }
 #endif
   }
+#if TRIPLE_TAP_BLE_DFU
+  else if (double_reset && !_ota_dfu && !serial_only_dfu && !uf2_dfu) {
+    // Second tap. USB DFU is where this ends up, but hold it off for one more window so a
+    // third tap can pick BLE OTA instead. Fast LED blink signals that the window is open.
+    led_state(STATE_DFU_MODE_SELECT);
+
+    // Register the second reset for triple reset detection
+    (*dbl_reset_mem) = DFU_TPL_RESET_MAGIC;
+
+    // if RST is pressed during this delay (triple reset) --> it will enter BLE OTA DFU
+    NRFX_DELAY_MS(DFU_TPL_RESET_DELAY);
+
+    // Window closed, no third tap. Restore the normal indication so that USB DFU below
+    // starts from exactly the LED state it would have had without the extra window.
+    led_state(STATE_BOOTLOADER_STARTED);
+  }
+#endif
 
   if (APP_ASKS_FOR_SINGLE_TAP_RESET()) {
     (*dbl_reset_mem) = DFU_DBL_RESET_APP;
@@ -289,6 +321,9 @@ static void check_dfu_mode(void) {
   if ((dfu_start || !valid_app) && !serial_only_dfu && !uf2_dfu && !double_reset) {
     _ota_dfu = true; // set default to OTA only when no explicit UF2/serial/dbl-reset
   }
+
+  // Triple tap always means BLE OTA, whatever the defaults above settled on
+  if (triple_reset) _ota_dfu = true;
 
   // Enter DFU mode accordingly to input
   if (dfu_start || !valid_app) {


### PR DESCRIPTION
## Checklist

- [x] Please provide specific title of the PR describing the change

-----------

## Description of Change

Adds a third tap to the reset gesture that already exists:

| Reset taps | Result |
| --- | --- |
| 1 | Normal boot into the application |
| 2 | USB DFU — UF2 drive + CDC serial |
| 3 | BLE OTA DFU |

### How it works

The no-init word at `0x20007F7C` already survives a pin reset in order to detect a double tap. It now holds a tap *stage* rather than a flag: `DFU_DBL_RESET_MAGIC` means one tap seen, the new `DFU_TPL_RESET_MAGIC` means two. The count has to live in that word because the `DBL_RESET` region in the linker script is exactly 4 bytes, and the `NOINIT` block above it is the OTA bond exchange area.

The second tap no longer falls straight through into USB DFU. It arms the third-tap magic and waits one more `DFU_TPL_RESET_DELAY` — 0.5s, matching the existing double-tap window. A third tap inside that window is picked up on the next boot and forces `_ota_dfu`, routing into the BLE OTA path already used by `DFU_MAGIC_OTA_RESET` (`bootloader_dfu_start(true, 0, false)`). If the window expires, the device enters USB DFU exactly as before.

The status LED blinks three times faster while the window is open, so it is visible that the third tap is available. It is restored before USB DFU starts, so neither destination sees an altered LED state.

### Why

Most boards here already have a button route into BLE OTA DFU — either the `BUTTON_DFU` + `BUTTON_FRESET` combo, or the single-button idiom of pointing both at the same pin so that holding one button on boot enters OTA. This is not trying to replace that.

What it adds is a route that needs no button at all, which matters in three cases:

1. **Boards with no usable button.** On the RAK 4631 and RAK 3401, `BUTTON_1` and `BUTTON_2` are both `P0.08`, which the board.h comment notes is *not connected*. There is no button route on those two: BLE OTA DFU can only be entered from the running application (buttonless DFU service / `GPREGRET`), or by having no valid application at all. A device running firmware that exposes no DFU service has no way in short of SWD.
2. **A device in an enclosure** where reset is reachable but the user button is not.
3. **Consistency** — the same gesture works everywhere, instead of the user having to know which button this particular board wants held.

### Scope

`TRIPLE_TAP_BLE_DFU` defaults to `1`. A board opts out by defining it as `0` in its `board.h`, which restores an immediate double-tap into USB DFU. It is forced off on nrf52832, where a GPIO reset clears SRAM so the tap state cannot survive — the same reason double-tap detection is already skipped there.

Everything new is behind `#if TRIPLE_TAP_BLE_DFU`, including the new `led_state()` case.

**Happy to narrow this to an opt-in for specific boards if you would rather** — that is a one-line change to the default, and the per-board `#define` mechanism is already in place.

### Trade-off

Double tap into USB DFU now takes 0.5s longer, on every board, because the bootloader has to wait to see whether a third tap is coming. That is inherent to the gesture and it is the main cost of this PR. `DFU_TPL_RESET_DELAY` is a separate constant from `DFU_DBL_RESET_DELAY` if you would prefer a different window.

### Flash cost

224–240 bytes. All 17 boards built from `master` and from this branch, with `__DATE__`/`__TIME__` pinned (`src/usb/uf2/compile_date.h` bakes them into the UF2 ghost FAT, so builds are otherwise not comparable):

| Board | before | after | after % of 38 KB |
| --- | --- | --- | --- |
| heltec_t114 | 35400 | 35624 | 91.6% |
| heltec_t096 | 35004 | 35228 | 90.5% |
| heltec_t1 | 34964 | 35204 | 90.5% |
| wismesh_tag | 33004 | 33228 | 85.4% |
| *(remaining 13 boards)* | | | 84.8% – 85.3% |

The fullest board after the change is `heltec_t114`, with about 3.2 KB of the region still free.

### Testing

- **Tested on RAK 4631 hardware.** All three gestures land in the expected mode.
- **Not tested on any other board's hardware.** The other 16 are build-verified only. The logic is board-independent — it touches only `check_dfu_mode()` and one `led_state()` case — but that is reasoning, not evidence, and it is worth saying plainly given this now defaults to on everywhere.
- All 17 boards compile clean under the project's `-Wall -Wextra -Werror`.

### Also

README gains an *Entering DFU mode* section describing the tap behaviour, plus short pointers to it from *Installation* and *Troubleshooting*.
